### PR TITLE
add hystrix metrics conf.

### DIFF
--- a/src/main/java/com/github/wdstar/springboot/example/WebMain.java
+++ b/src/main/java/com/github/wdstar/springboot/example/WebMain.java
@@ -15,6 +15,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.web.client.RestTemplate;
 
+import io.micrometer.core.instrument.binder.hystrix.HystrixMetricsBinder;
+
 @SpringBootApplication
 @EnableCircuitBreaker
 @EnableHystrixDashboard
@@ -30,6 +32,11 @@ public class WebMain {
 		return factory -> factory.configureDefault(id -> HystrixCommand.Setter
 				.withGroupKey(HystrixCommandGroupKey.Factory.asKey(id)).andCommandPropertiesDefaults(
 						HystrixCommandProperties.Setter().withExecutionTimeoutInMilliseconds(3000)));
+	}
+
+	@Bean
+	public HystrixMetricsBinder registerHystrixMetricsBinder() {
+		return new HystrixMetricsBinder();
 	}
 
 	@Bean


### PR DESCRIPTION
I add Hystrix metrics configurations.
- Sample logs
```
$ curl -s http://localhost:8080/actuator/prometheus | grep hystrix | head
# HELP hystrix_threadpool_queue_current_size Current size of BlockingQueue used by the thread-pool.
# TYPE hystrix_threadpool_queue_current_size gauge
hystrix_threadpool_queue_current_size{key="targetMethod",} 0.0
# HELP hystrix_circuit_breaker_open
# TYPE hystrix_circuit_breaker_open gauge
hystrix_circuit_breaker_open{group="targetMethod",key="HystrixCircuitBreaker$1",} 0.0
# HELP hystrix_threadpool_threads_pool_current_size The current number of threads in the pool.
# TYPE hystrix_threadpool_threads_pool_current_size gauge
hystrix_threadpool_threads_pool_current_size{key="targetMethod",} 5.0
# HELP hystrix_threadpool_threads_max_pool_current_size The maximum allowed number of threads.
```